### PR TITLE
64 fix user registration email validation not showing all errorhelp messages

### DIFF
--- a/src/components/form/textInput/index.js
+++ b/src/components/form/textInput/index.js
@@ -113,7 +113,7 @@ const TextInput = ({
           value={value}
           onChange={handleChange}
           pattern={emailPattern}
-          className={icon && 'input-has-icon'}
+          className={(error && 'input-error') || (icon && 'input-has-icon')}
         />
         {icon && <span className="input-icon">{icon}</span>}
         {error && <span className="error-message">{error}</span>}

--- a/src/components/form/textInput/index.js
+++ b/src/components/form/textInput/index.js
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 /**
  * validChars: Characters that are allowed in the input, the user can't type characters that are not included in validChars
  * -
- * pattern: Required pattern/format for e.g. email and password.
+ * pattern: Required pattern/format for email or password.
  * patternDescription: Requirements can be passed in via patternDescription, it will be displayed as help messages to the user if the input doesn't match the pattern
  */
 const TextInput = ({
@@ -25,7 +25,6 @@ const TextInput = ({
   const [input, setInput] = useState('');
   const [error, setError] = useState('');
   const [showpassword, setShowpassword] = useState(false);
-  const emailPattern = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/;
 
   useEffect(() => {
     if (isRequired && value.length === 0) {
@@ -132,7 +131,7 @@ const TextInput = ({
           name={name}
           value={value}
           onChange={handleChange}
-          pattern={emailPattern}
+          pattern={pattern}
           className={(error && 'input-error') || (icon && 'input-has-icon')}
         />
         {icon && <span className="input-icon">{icon}</span>}

--- a/src/pages/register/index.js
+++ b/src/pages/register/index.js
@@ -12,7 +12,10 @@ const Register = () => {
   const [errorMessage, setErrorMessage] = useState('');
 
   // Email validation
-  const isValidEmail = formData.email.match(/^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/);
+  const emailPatternDescription = 'Please enter a valid email address';
+  const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/;
+  const emailRegexValidChars = 'A-Za-z0-9@._-';
+  const isValidEmail = formData.email.match(emailRegex);
 
   // Password validation
   // The password should not be less than 8 characters in length
@@ -53,7 +56,9 @@ const Register = () => {
               name="email"
               label={'Email *'}
               isRequired={true}
-              validChars={'A-Za-z0-9@._-'}
+              validChars={emailRegexValidChars}
+              pattern={emailRegex}
+              patternDescription={emailPatternDescription}
             />
             <TextInput
               value={formData.password}


### PR DESCRIPTION
- The inputs now have the same styling (red border when not valid):
![image](https://github.com/user-attachments/assets/0a7cbf97-9900-44bc-af54-e50d06eb79ae)

- If the user types an invalid email, this help/error message is shown:
![image](https://github.com/user-attachments/assets/79d5e571-de7d-45e7-882c-7ce0ed86dc87)

- For correct email format, the input looks like this:
![image](https://github.com/user-attachments/assets/e190eca3-3aed-4bf1-9fce-2513e9cd36ac)

- NOTE! There are some duplicated code parts in `src/components/form/textInput/index.js` for the email return statement and the general input return statement. I didn't combine them as I don't know if it will break the code if I add the props attribute 'pattern' to the general input. At the moment it's only possible to use 'pattern' together with inputs which are of type `email` or `password`.