### PR TITLE
65 fill up my cohort list on dashboard

### DIFF
--- a/src/pages/dashboard/index.js
+++ b/src/pages/dashboard/index.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import SearchIcon from '../../assets/icons/searchIcon';
 import Button from '../../components/button';
 import Card from '../../components/card';
@@ -7,9 +7,34 @@ import TextInput from '../../components/form/textInput';
 import Posts from '../../components/posts';
 import useModal from '../../hooks/useModal';
 import './style.css';
+import { getCohorts } from '../../service/apiClient';
+import useAuth from '../../hooks/useAuth';
+
+// eslint-disable-next-line camelcase
+import jwt_decode from 'jwt-decode';
+import { NavLink } from 'react-router-dom';
 
 const Dashboard = () => {
   const [searchVal, setSearchVal] = useState('');
+  const [cohorts, setCohorts] = useState([]);
+  const { token } = useAuth();
+
+  useEffect(() => {
+    const fetchCohorts = async () => {
+      const allCohorts = await getCohorts();
+      const cohortToAdd = [];
+      const { userId } = jwt_decode(token);
+      // Map out the cohorts to check if the user is in the cohort
+      allCohorts.forEach((cohort) => {
+        if (cohort.users.some((user) => user.id === userId)) {
+          cohortToAdd.push(cohort);
+        }
+      });
+      // SET STARTING POINT OF THE COHORT TO THE FIRST COHORT IN THE ARRAY
+      setCohorts(cohortToAdd);
+    };
+    fetchCohorts();
+  }, []);
 
   const onChange = (e) => {
     setSearchVal(e.target.value);
@@ -50,7 +75,32 @@ const Dashboard = () => {
         </Card>
 
         <Card>
-          <h4>My Cohort</h4>
+          <div className="cohort-title dashboard-cohort-title">
+            <h4>Cohorts</h4>
+          </div>
+          <div className="dashboard-cohort">
+            {cohorts.map((cohort) => {
+              return (
+                <NavLink
+                  to="/cohort"
+                  state={{ cohortId: cohort.id }}
+                  key={cohort.id}
+                  className={'cohort-nav-link'}
+                >
+                  <div className="post-details cohort-div">
+                    <div className="profile-icon">
+                      <p>&lt; &gt;</p>
+                    </div>
+                    <div className="post-user-name cohort-student-name">
+                      <p>
+                        {cohort.name} {cohort.id}
+                      </p>
+                    </div>
+                  </div>
+                </NavLink>
+              );
+            }, [])}
+          </div>
         </Card>
       </aside>
     </>

--- a/src/pages/dashboard/style.css
+++ b/src/pages/dashboard/style.css
@@ -19,3 +19,22 @@ aside {
   max-width: 100% !important;
   background-color: var(--color-blue5);
 }
+
+.cohort-nav-link {
+  text-decoration: none;
+}
+
+.cohort-div {
+  margin-top: 15px;
+}
+
+.dashboard-cohort  {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(365px, 1fr));
+  max-height: 400px;
+  overflow: auto;
+}
+
+.dashboard-cohort-title {
+  margin-bottom: 0rem !important;
+}


### PR DESCRIPTION
Finished with the cohort list on the dashboard and so when the user clicks on one of them, the user will be directed to the specific cohort

The view should be like this: 
![image](https://github.com/user-attachments/assets/15ae690d-6dc4-40c8-97ed-36ebc3e27756)


## For Testing
Follow these steps to have the proper outcome of my PR.
### Backend
Hopefully you have cohorts already in your database. If you do, you should be able to see the cohorts the user has right now.
Otherwise you need to add cohorts, add the user you are signed in as to the cohort. 


### Frontend
When you are signed in as the user and the user you are signed in as will see your cohorts.
1. Click on the cohort you want to see. You will be directed to the cohort and see the cohort on the cohort page.
2. Go back to dashboard and click on another one.
3. If it works as intended you will see that one instead.


![image](https://github.com/user-attachments/assets/d6499abe-76cc-454b-abf0-92712c9292d9)

